### PR TITLE
Resolves miscellaneous Windows build errors

### DIFF
--- a/NXSYS/ldgut.cpp
+++ b/NXSYS/ldgut.cpp
@@ -8,6 +8,7 @@ class Relay;
 #include "RLYINDEX.H"
 #include "compat32.h"
 #include "PolyKludge.h"
+#include "MessageBox.h"
 #include <string>
 #include <vector>
 

--- a/NXSYS/v2/xtgtrack.h
+++ b/NXSYS/v2/xtgtrack.h
@@ -4,6 +4,7 @@
 /* NXSYS Extended Geometry System  1 January 1997 */
 
 #include <vector>   // 27 Sept 2019 for SegArray
+#include <string>
 #include "nxgo.h"
 #ifndef TLEDIT
 #ifndef REALLY_NXSYS

--- a/NXSYSWindows/NXSYS/NXSYS.vcxproj
+++ b/NXSYSWindows/NXSYS/NXSYS.vcxproj
@@ -104,11 +104,11 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\NXSYS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir)..\Documentation $(OutDir)Documentation /E
-robocopy $(SolutionDir)..\Documentation\HelpImages $(OutDir)Pages\HelpImages /E
-robocopy $(SolutionDir)..\Interlockings $(OutDir)Interlockings /E
-copy $(SolutionDir)..\Help.xml $(OutDir)Help.xml
-copy $(SolutionDir)..\InterlockingLibrary.xml $(OutDir)InterlockingLibrary.xml</Command>
+      <Command>robocopy "$(SolutionDir)..\Documentation" "$(OutDir)Documentation" /E
+robocopy "$(SolutionDir)..\Documentation\HelpImages" "$(OutDir)Pages\HelpImages" /E
+robocopy "$(SolutionDir)..\Interlockings" "$(OutDir)Interlockings" /E
+copy "$(SolutionDir)..\Help.xml" "$(OutDir)Help.xml"
+copy "$(SolutionDir)..\InterlockingLibrary.xml" "$(OutDir)InterlockingLibrary.xml"</Command>
       <Outputs>$(OutputDir)Pages</Outputs>
       <TreatOutputAsContent>true</TreatOutputAsContent>
     </CustomBuildStep>
@@ -153,10 +153,10 @@ copy $(SolutionDir)..\InterlockingLibrary.xml $(OutDir)InterlockingLibrary.xml</
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)..\NXSYS\v2;$(SolutionDir)..\NXSYS;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir)..\Documentation $(OutDir)Documentation /E
-copy $(SolutionDir)..\InterlockingLibrary.xml $(OutDir)\InterlockingLibrary /Y
-robocopy $(SolutionDir)..\Interlockings $(OutDir)\Interlockings /E
-copy $(SolutionDir)..\Help.xml $(OutDir)\ /Y</Command>
+      <Command>robocopy "$(SolutionDir)..\Documentation" "$(OutDir)Documentation" /E
+copy "$(SolutionDir)..\InterlockingLibrary.xml" "$(OutDir)\InterlockingLibrary" /Y
+robocopy "$(SolutionDir)..\Interlockings" "$(OutDir)\Interlockings" /E
+copy "$(SolutionDir)..\Help.xml" "$(OutDir)\" /Y</Command>
       <TreatOutputAsContent>true</TreatOutputAsContent>
       <Outputs>$(OutputDir)Documentation</Outputs>
     </CustomBuildStep>

--- a/NXSYSWindows/TLEdit/TLEdit.vcxproj
+++ b/NXSYSWindows/TLEdit/TLEdit.vcxproj
@@ -143,7 +143,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)..\TLEdit\tled</AdditionalIncludeDirectories>
     </ResourceCompile>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir)..\TLEDocumentation $(OutDir)TLEDocumentation
+      <Command>robocopy "$(SolutionDir)..\TLEDocumentation" "$(OutDir)TLEDocumentation"
 if %errorlevel% geq 8 exit %errorlevel%
 exit 0</Command>
     </CustomBuildStep>

--- a/TLEdit/tled/objreg.cpp
+++ b/TLEdit/tled/objreg.cpp
@@ -6,6 +6,7 @@
 #include "objreg.h"
 #include "LoadFiascoMaps.h"
 #include <unordered_map>
+#include <string>
 
 /* Rewritten for dyn-create STL 4/9/2022 */
 


### PR DESCRIPTION
Adds a couple of missing #includes and wraps copy commands in quotes to prevent issues from cloning at a path with spaces