### PR TITLE
Updates Windows installer to version 2.7.1

### DIFF
--- a/NXSYSWindows/Installer/Installer.vdproj
+++ b/NXSYSWindows/Installer/Installer.vdproj
@@ -33,12 +33,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_1565972D6195484FBF776ACF57662C94"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_18E7BF7A9CF9439EA87B459C377C9474"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -64,12 +58,6 @@
         "Entry"
         {
         "MsmKey" = "8:_1D1EB29DDEBA416D961CA9BEB9F7861B"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_1F68242E048B4BA7BF25DB3C5DB6FA66"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -141,6 +129,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_31121FAE9F3D4D6BA124BD1D3C2D5C0F"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_31190CCFB6FB45A6B9F7E592D18B1030"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -154,12 +148,6 @@
         "Entry"
         {
         "MsmKey" = "8:_32FE93859BE84D118F0544B5CC6EAF67"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_35D4B97DD2E145318B3D79E92E342DF3"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -214,12 +202,6 @@
         "Entry"
         {
         "MsmKey" = "8:_4DA2BEB36F6F42D1B753695149C59777"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_4DAC3D37B5544C9BB6070426E5940BC2"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -286,12 +268,6 @@
         "Entry"
         {
         "MsmKey" = "8:_6240F3633C124388ADF411466B899EBA"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_62463C3E61CB4BC998223A0AF9EBA263"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -399,18 +375,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_8D0CD552AB1E45068FA9D3509CAA8AB4"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_90B4B84B89924F9DBCAB2AC27C11ECFB"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_90E348AC4D6B4B35B615DFF9B53D5AC3"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -447,12 +411,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_985065413F3A464F89D7ADBCA85C7FFD"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_98B9B4D86A6C4AEE9432894196EAACAE"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -465,25 +423,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_9DD2192195C04A55994DDF0D95B9A5EC"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_9E3158B3F5DF4525A9A391690FAAFEDC"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_9FBBD4945F524F9FBEAC52896A7FAB3C"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_A1AC08A7B2A24FC580624B02B4AC0774"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -645,19 +585,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_ED8653DC30AA488BBDF1F5E1DE3A2064"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_F0FAA508BF6B4D49818B73BB5BC46D5F"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_F732D49AC6164E309B846B8E3CE60D90"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -743,6 +671,11 @@
                     "Name" = "8:Microsoft .NET Framework 4.7.2 (x86 and x64)"
                     "ProductCode" = "8:.NETFramework,Version=v4.7.2"
                     }
+                    "{EDC2488A-8267-493A-A98E-7D9C3B36CDF3}:Microsoft.Visual.C++.14.0.x64"
+                    {
+                    "Name" = "8:Visual C++ \"14\" Runtime Libraries (x64)"
+                    "ProductCode" = "8:Microsoft.Visual.C++.14.0.x64"
+                    }
                 }
             }
         }
@@ -812,26 +745,6 @@
             "TargetName" = "8:TrafficLevers2_5.html"
             "Tag" = "8:"
             "Folder" = "8:_EEE3E068D24B440698C1C3A4D60AC5C3"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_1565972D6195484FBF776ACF57662C94"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\msvcp140_2.dll"
-            "TargetName" = "8:msvcp140_2.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -932,26 +845,6 @@
             "TargetName" = "8:irt.yard.trk"
             "Tag" = "8:"
             "Folder" = "8:_40410CADCBAF4D2FAC01139A96C97F2B"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_1F68242E048B4BA7BF25DB3C5DB6FA66"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\vccorlib140.dll"
-            "TargetName" = "8:vccorlib140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1186,6 +1079,26 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_31121FAE9F3D4D6BA124BD1D3C2D5C0F"
+            {
+            "SourcePath" = "8:..\\..\\TLEDocumentation\\TLEdit.pdf"
+            "TargetName" = "8:TLEdit.pdf"
+            "Tag" = "8:"
+            "Folder" = "8:_223FF2A039484C07B455977D5853E117"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_31190CCFB6FB45A6B9F7E592D18B1030"
             {
             "SourcePath" = "8:..\\..\\Documentation\\HelpImages\\fleeted.png"
@@ -1230,26 +1143,6 @@
             {
             "SourcePath" = "8:..\\..\\LICENSE"
             "TargetName" = "8:LICENSE"
-            "Tag" = "8:"
-            "Folder" = "8:_EEE3E068D24B440698C1C3A4D60AC5C3"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_35D4B97DD2E145318B3D79E92E342DF3"
-            {
-            "SourcePath" = "8:..\\..\\Documentation\\CommonReleaseNotes.html"
-            "TargetName" = "8:CommonReleaseNotes.html"
             "Tag" = "8:"
             "Folder" = "8:_EEE3E068D24B440698C1C3A4D60AC5C3"
             "Condition" = "8:"
@@ -1432,26 +1325,6 @@
             "TargetName" = "8:clbogus.bmp"
             "Tag" = "8:"
             "Folder" = "8:_198B957CAE3D48009F0AD61C42ADFD2B"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_4DAC3D37B5544C9BB6070426E5940BC2"
-            {
-            "SourcePath" = "8:..\\..\\TLEDocumentation\\MacTleHelp.html"
-            "TargetName" = "8:MacTleHelp.html"
-            "Tag" = "8:"
-            "Folder" = "8:_223FF2A039484C07B455977D5853E117"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1672,26 +1545,6 @@
             "TargetName" = "8:stdmacs.trk"
             "Tag" = "8:"
             "Folder" = "8:_6C3BDEDE01194523B8DDCA44BB679A7F"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_62463C3E61CB4BC998223A0AF9EBA263"
-            {
-            "SourcePath" = "8:..\\..\\TLEDocumentation\\tletoolb.png"
-            "TargetName" = "8:tletoolb.png"
-            "Tag" = "8:"
-            "Folder" = "8:_223FF2A039484C07B455977D5853E117"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -2046,46 +1899,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_8D0CD552AB1E45068FA9D3509CAA8AB4"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\concrt140.dll"
-            "TargetName" = "8:concrt140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_90B4B84B89924F9DBCAB2AC27C11ECFB"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\msvcp140_codecvt_ids.dll"
-            "TargetName" = "8:msvcp140_codecvt_ids.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_90E348AC4D6B4B35B615DFF9B53D5AC3"
             {
             "SourcePath" = "8:..\\..\\Documentation\\RelayLanguage.html"
@@ -2206,26 +2019,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_985065413F3A464F89D7ADBCA85C7FFD"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\msvcp140.dll"
-            "TargetName" = "8:msvcp140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_98B9B4D86A6C4AEE9432894196EAACAE"
             {
             "SourcePath" = "8:..\\..\\TLEdit\\tled\\tle.ico"
@@ -2266,70 +2059,10 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_9DD2192195C04A55994DDF0D95B9A5EC"
-            {
-            "SourcePath" = "8:..\\..\\TLEDocumentation\\TLEdit.html"
-            "TargetName" = "8:TLEdit.html"
-            "Tag" = "8:"
-            "Folder" = "8:_223FF2A039484C07B455977D5853E117"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_9E3158B3F5DF4525A9A391690FAAFEDC"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\vcruntime140.dll"
-            "TargetName" = "8:vcruntime140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_9FBBD4945F524F9FBEAC52896A7FAB3C"
             {
             "SourcePath" = "8:..\\..\\Help.xml"
             "TargetName" = "8:Help.xml"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_A1AC08A7B2A24FC580624B02B4AC0774"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\msvcp140_atomic_wait.dll"
-            "TargetName" = "8:msvcp140_atomic_wait.dll"
             "Tag" = "8:"
             "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
             "Condition" = "8:"
@@ -2866,52 +2599,12 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_ED8653DC30AA488BBDF1F5E1DE3A2064"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\msvcp140_1.dll"
-            "TargetName" = "8:msvcp140_1.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_F0FAA508BF6B4D49818B73BB5BC46D5F"
             {
             "SourcePath" = "8:..\\..\\Interlockings\\Myrtle\\myrtlayt.trk"
             "TargetName" = "8:myrtlayt.trk"
             "Tag" = "8:"
             "Folder" = "8:_A9B4FCE9F0B74CB9B77331A16BF7CDBA"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_F732D49AC6164E309B846B8E3CE60D90"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x64\\Microsoft.VC143.CRT\\vcruntime140_1.dll"
-            "TargetName" = "8:vcruntime140_1.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_31133C30B0C548009B5A7472B912A9D4"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -3164,7 +2857,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:NXSYS"
         "ProductCode" = "8:{CC7A0688-FAF1-4157-8868-2081DFDF3522}"
-        "PackageCode" = "8:{25B3633E-AA73-4608-8305-697C04177DE0}"
+        "PackageCode" = "8:{C8DDBCA3-2A8A-4299-B3FD-1C349EC4172E}"
         "UpgradeCode" = "8:{59B1A06F-08D5-49FD-90F6-2245A4356957}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"

--- a/NXSYSWindows/Setup32/Setup32.vdproj
+++ b/NXSYSWindows/Setup32/Setup32.vdproj
@@ -51,6 +51,12 @@
         }
         "Entry"
         {
+        "MsmKey" = "8:_13A248766F6C4331947929AC47D88BA1"
+        "OwnerKey" = "8:_UNDEFINED"
+        "MsmSig" = "8:_UNDEFINED"
+        }
+        "Entry"
+        {
         "MsmKey" = "8:_1586C450BBD34CDD9AAC39FF1EAC1292"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -124,12 +130,6 @@
         "Entry"
         {
         "MsmKey" = "8:_3A9A0B6371314E4E995E38D2463A7AB9"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_3D2F7F30C2944C4F877CCB4AC29F7205"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -231,19 +231,7 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_5E92893B9E334583A0AF614A792B97CF"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_6370725941884D97A47917DEC677A0C2"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_6870AFF9FD594689B62F500A49FADD71"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -274,12 +262,6 @@
         "Entry"
         {
         "MsmKey" = "8:_6EC9FD4DA81C4A57952824AEF113762A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_7523C5D5113C43ECB097FAC848A05DEE"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -364,12 +346,6 @@
         "Entry"
         {
         "MsmKey" = "8:_9309E1FB6E04454781EF5FC0E89C35AB"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_955519328C96469BBD1BC74AEEC091F9"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -471,18 +447,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_C2FE9D4194464D81B34C0CA4CD3E8567"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_C3B9FF931DA34FF78642211F9616DD86"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_C4FAE4555FDD4EDE9F6647B25A437127"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -502,12 +466,6 @@
         "Entry"
         {
         "MsmKey" = "8:_D1B37F8D1D6341FEAADACDF2A46010F9"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D373117211604A78868AE62F53A5F176"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -544,12 +502,6 @@
         "Entry"
         {
         "MsmKey" = "8:_D6F83C1459824048A7DD2A7AA2522A7A"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_D800527A78254B5AB595E8E74F0B2C72"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -603,12 +555,6 @@
         }
         "Entry"
         {
-        "MsmKey" = "8:_E21D883FB9114ABEBBF854F361653955"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
         "MsmKey" = "8:_E28623EA062C40A0B114EBF7654A7ED6"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
@@ -646,12 +592,6 @@
         "Entry"
         {
         "MsmKey" = "8:_ED3EDAB21DA44E20B59FF6B171FED428"
-        "OwnerKey" = "8:_UNDEFINED"
-        "MsmSig" = "8:_UNDEFINED"
-        }
-        "Entry"
-        {
-        "MsmKey" = "8:_EE016CCC671346D4B76534A6DC7BB6A0"
         "OwnerKey" = "8:_UNDEFINED"
         "MsmSig" = "8:_UNDEFINED"
         }
@@ -742,6 +682,11 @@
                     {
                     "Name" = "8:Microsoft .NET Framework 4.7.2 (x86 and x64)"
                     "ProductCode" = "8:.NETFramework,Version=v4.7.2"
+                    }
+                    "{EDC2488A-8267-493A-A98E-7D9C3B36CDF3}:Microsoft.Visual.C++.14.0.x86"
+                    {
+                    "Name" = "8:Visual C++ \"14\" Runtime Libraries (x86)"
+                    "ProductCode" = "8:Microsoft.Visual.C++.14.0.x86"
                     }
                 }
             }
@@ -872,6 +817,26 @@
             "TargetName" = "8:ad.bmp"
             "Tag" = "8:"
             "Folder" = "8:_B33FB2D70AFD4CC88521B3BA3B582D31"
+            "Condition" = "8:"
+            "Transitive" = "11:FALSE"
+            "Vital" = "11:TRUE"
+            "ReadOnly" = "11:FALSE"
+            "Hidden" = "11:FALSE"
+            "System" = "11:FALSE"
+            "Permanent" = "11:FALSE"
+            "SharedLegacy" = "11:FALSE"
+            "PackageAs" = "3:1"
+            "Register" = "3:1"
+            "Exclude" = "11:FALSE"
+            "IsDependency" = "11:FALSE"
+            "IsolateTo" = "8:"
+            }
+            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_13A248766F6C4331947929AC47D88BA1"
+            {
+            "SourcePath" = "8:..\\..\\TLEDocumentation\\TLEdit.pdf"
+            "TargetName" = "8:TLEdit.pdf"
+            "Tag" = "8:"
+            "Folder" = "8:_797A75C00CD248769232A4C5489DBC1F"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1132,26 +1097,6 @@
             "TargetName" = "8:divrt.bmp"
             "Tag" = "8:"
             "Folder" = "8:_B33FB2D70AFD4CC88521B3BA3B582D31"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_3D2F7F30C2944C4F877CCB4AC29F7205"
-            {
-            "SourcePath" = "8:..\\..\\Documentation\\CommonReleaseNotes.html"
-            "TargetName" = "8:CommonReleaseNotes.html"
-            "Tag" = "8:"
-            "Folder" = "8:_A94AE27ECA09476FA9AA25B8686C9AB5"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1486,52 +1431,12 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_5E92893B9E334583A0AF614A792B97CF"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\vcruntime140.dll"
-            "TargetName" = "8:vcruntime140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_6370725941884D97A47917DEC677A0C2"
             {
             "SourcePath" = "8:..\\..\\Interlockings\\Atlantic\\aatraffic.trk"
             "TargetName" = "8:aatraffic.trk"
             "Tag" = "8:"
             "Folder" = "8:_0AC0207A10D546D9BEE43335E9164FA4"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_6870AFF9FD594689B62F500A49FADD71"
-            {
-            "SourcePath" = "8:..\\..\\TLEDocumentation\\TLEdit.html"
-            "TargetName" = "8:TLEdit.html"
-            "Tag" = "8:"
-            "Folder" = "8:_797A75C00CD248769232A4C5489DBC1F"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1632,26 +1537,6 @@
             "TargetName" = "8:fsd.bmp"
             "Tag" = "8:"
             "Folder" = "8:_B33FB2D70AFD4CC88521B3BA3B582D31"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_7523C5D5113C43ECB097FAC848A05DEE"
-            {
-            "SourcePath" = "8:..\\..\\TLEDocumentation\\tletoolb.png"
-            "TargetName" = "8:tletoolb.png"
-            "Tag" = "8:"
-            "Folder" = "8:_797A75C00CD248769232A4C5489DBC1F"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -1932,26 +1817,6 @@
             "TargetName" = "8:ledblx.bmp"
             "Tag" = "8:"
             "Folder" = "8:_B33FB2D70AFD4CC88521B3BA3B582D31"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_955519328C96469BBD1BC74AEEC091F9"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\msvcp140.dll"
-            "TargetName" = "8:msvcp140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -2286,46 +2151,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_C2FE9D4194464D81B34C0CA4CD3E8567"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\vccorlib140.dll"
-            "TargetName" = "8:vccorlib140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_C3B9FF931DA34FF78642211F9616DD86"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\msvcp140_atomic_wait.dll"
-            "TargetName" = "8:msvcp140_atomic_wait.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_C4FAE4555FDD4EDE9F6647B25A437127"
             {
             "SourcePath" = "8:..\\..\\Documentation\\HelpImages\\nxgl2.bmp"
@@ -2390,26 +2215,6 @@
             {
             "SourcePath" = "8:..\\..\\InterlockingLibrary.xml"
             "TargetName" = "8:InterlockingLibrary.xml"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_D373117211604A78868AE62F53A5F176"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\msvcp140_codecvt_ids.dll"
-            "TargetName" = "8:msvcp140_codecvt_ids.dll"
             "Tag" = "8:"
             "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
             "Condition" = "8:"
@@ -2532,26 +2337,6 @@
             "TargetName" = "8:myrtle.trk"
             "Tag" = "8:"
             "Folder" = "8:_FCE741E9B4D1486A8710B8F8C94F4AE7"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_D800527A78254B5AB595E8E74F0B2C72"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\msvcp140_2.dll"
-            "TargetName" = "8:msvcp140_2.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -2726,26 +2511,6 @@
             "IsDependency" = "11:FALSE"
             "IsolateTo" = "8:"
             }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_E21D883FB9114ABEBBF854F361653955"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\msvcp140_1.dll"
-            "TargetName" = "8:msvcp140_1.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
             "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_E28623EA062C40A0B114EBF7654A7ED6"
             {
             "SourcePath" = "8:..\\..\\Interlockings\\Duckburg\\README.md"
@@ -2872,26 +2637,6 @@
             "TargetName" = "8:NXSYS.html"
             "Tag" = "8:"
             "Folder" = "8:_A94AE27ECA09476FA9AA25B8686C9AB5"
-            "Condition" = "8:"
-            "Transitive" = "11:FALSE"
-            "Vital" = "11:TRUE"
-            "ReadOnly" = "11:FALSE"
-            "Hidden" = "11:FALSE"
-            "System" = "11:FALSE"
-            "Permanent" = "11:FALSE"
-            "SharedLegacy" = "11:FALSE"
-            "PackageAs" = "3:1"
-            "Register" = "3:1"
-            "Exclude" = "11:FALSE"
-            "IsDependency" = "11:FALSE"
-            "IsolateTo" = "8:"
-            }
-            "{1FB2D0AE-D3B9-43D4-B9DD-F88EC61E35DE}:_EE016CCC671346D4B76534A6DC7BB6A0"
-            {
-            "SourcePath" = "8:C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Redist\\MSVC\\14.31.31103\\x86\\Microsoft.VC143.CRT\\concrt140.dll"
-            "TargetName" = "8:concrt140.dll"
-            "Tag" = "8:"
-            "Folder" = "8:_CCBACE9A5AEC4F379B4F9CE83E5CF6CC"
             "Condition" = "8:"
             "Transitive" = "11:FALSE"
             "Vital" = "11:TRUE"
@@ -3164,7 +2909,7 @@
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:NXSYS32"
         "ProductCode" = "8:{46E87C6E-99B2-4C6F-B8E7-227506447649}"
-        "PackageCode" = "8:{490BBC47-2FE9-4C53-9185-0887127F05BF}"
+        "PackageCode" = "8:{358937E6-05F5-45C8-A14A-6E124620693A}"
         "UpgradeCode" = "8:{C6264AAB-9A86-4387-AD3D-A2999B412ADB}"
         "AspNetVersion" = "8:4.0.30319.0"
         "RestartWWWService" = "11:FALSE"


### PR DESCRIPTION
Updates referenced files for newer documentation and, more importantly, resolves the previous issues with DLLs by packaging the C++ Redistributables as a prerequisite rather than manually packaging individual DLLs with the installer.